### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@master
 
       - name: Publish to Dockerhub
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: luqmansen/gosty-loadtest
           dockerfile: locust/Dockerfile


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore